### PR TITLE
npm requires version to be in format X.Y.Z

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name" : "JSV",
-	"version" : "3.3",
+	"version" : "3.3.0",
 	"description" : "A JavaScript implementation of a extendable, fully compliant JSON Schema validator.",
 	"homepage" : "http://github.com/garycourt/JSV",
 	"author" : "Gary Court <gary.court@gmail.com>",


### PR DESCRIPTION
See error below:

```
[silas@x201 JSV]$ npm install
npm info it worked if it ends with ok
npm info using npm@0.2.17
npm info using node@v0.2.6
npm ERR! couldn't read package.json in .
npm ERR! Error installing .
npm ERR! Error: Invalid version: 3.3
npm ERR! Must be X.Y.Z, with an optional trailing tag.
npm ERR! See the section on 'version' in `npm help json`
npm ERR!     at /home/silas/.local/lib/node/.npm/npm/0.2.17/package/lib/utils/read-json.js:156:13
npm ERR!     at /home/silas/.local/lib/node/.npm/npm/0.2.17/package/lib/utils/read-json.js:81:32
npm ERR!     at P (/home/silas/.local/lib/node/.npm/npm/0.2.17/package/lib/utils/read-json.js:62:40)
npm ERR!     at cb (/home/silas/.local/lib/node/.npm/npm/0.2.17/package/lib/utils/graceful-fs.js:32:9)
npm ERR!     at fs:84:13
npm ERR!     at node.js:773:9
npm ERR! Report this *entire* log at <http://github.com/isaacs/npm/issues>
npm ERR! or email it to <npm-@googlegroups.com>
npm ERR! Just tweeting a tiny part of the error will not be helpful.
npm not ok
```
