### PR TITLE
Typo in clone()

### DIFF
--- a/lib/jsv.js
+++ b/lib/jsv.js
@@ -584,7 +584,7 @@ var exports = exports || this,
 				}
 				return newObj;
 			} else {
-				return Array.pototype.slice.call(obj);
+				return Array.prototype.slice.call(obj);
 			}
 			break;
 		default:


### PR DESCRIPTION
Causes an error when calling clone([1,2], false);

Not sure if this non-deep path is ever used by JSV, at least I only saw this error when calling it explicitly.

It would be smart to add some test for this path. Might add later if I get time.
