### PR TITLE
Correct type of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 			"url" : "git://github.com/garycourt/JSV.git"
 		}
 	],
-	"dependencies" : [],
+	"dependencies" : {},
 	"main" : "lib/jsv.js",
 	"keywords" : ["json", "schema", "validator"]
 }


### PR DESCRIPTION
According to https://npmjs.org/doc/json.html the dependencies should be a hash, not an array, and some things barf when they see an array here.
