### PR TITLE
Add an option to skip schema validation

### DIFF
--- a/lib/jsv.js
+++ b/lib/jsv.js
@@ -1137,10 +1137,11 @@ var exports = exports || this,
 	 * 
 	 * @param {JSONInstance|Any} instanceJSON The {@link JSONInstance} or JavaScript value to validate.
 	 * @param {JSONSchema|Any} schemaJSON The {@link JSONSchema} or JavaScript value to use in the validation. This will also be validated againt the schema's schema.
+	 * @param {Boolean} [skipSchemaValidation=false] If the provided schema should not be validated
 	 * @returns {Report} The result of the validation
 	 */
 	
-	Environment.prototype.validate = function (instanceJSON, schemaJSON) {
+	Environment.prototype.validate = function (instanceJSON, schemaJSON, skipSchemaValidation) {
 		var instance,
 			schema,
 			schemaSchema,
@@ -1163,7 +1164,7 @@ var exports = exports || this,
 			report.addError(f.uri, f.schemaUri, f.attribute, f.message, f.details);
 		}
 		
-		if (schemaSchema) {
+		if (schemaSchema && !skipSchemaValidation) {
 			schemaSchema.validate(schema, report);
 		}
 			


### PR DESCRIPTION
If you are validating many instances with the same schema, it's not necessary to revalidate the schema each time. I've added an option to `Environment.prototype.validate` to skip schema validation.
