### PR TITLE
Fix npm "dependencies" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,10 @@
 		"mail" : "gary.court@gmail.com",
 		"web" : "http://github.com/garycourt/JSV/issues"
 	},
-	"repositories" : [
-		{
-			"type" : "git",
-			"url" : "git://github.com/garycourt/JSV.git"
-		}
-	],
+	"repository" : {
+    "type" : "git",
+    "url" : "git://github.com/garycourt/JSV.git"
+  },
 	"dependencies" : [],
 	"main" : "lib/jsv.js",
 	"keywords" : ["json", "schema", "validator"]


### PR DESCRIPTION
npm is issuing the following warning when using JSV:

```
npm WARN package.json JSV@4.0.2 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

This commit changes the `repositories` key in `package.json` to `repository` as
per the new npm package schema:

https://npmjs.org/doc/files/package.json.html
#78 is a very similar pull request, except it doesn't remove the array.
