### PR TITLE
Rework jsv.js export/require shim to match uri.js

### DIFF
--- a/lib/jsv.js
+++ b/lib/jsv.js
@@ -37,10 +37,14 @@
 
 /*jslint white: true, sub: true, onevar: true, undef: true, eqeqeq: true, newcap: true, immed: true, indent: 4 */
 
-var exports = exports || this,
-	require = require || function () {
+if (typeof exports === "undefined") {
+	exports = {}; 
+}
+if (typeof require !== "function") {
+	require = function (id) {
 		return exports;
 	};
+}
 
 (function () {
 	


### PR DESCRIPTION
[Webpack](https://webpack.github.io) doesn't detect the require() statements in jsv.js as-is - I tracked this down to the exports re-definition.  The form used in uri.js works correctly in both Webpack and all the test pages, so I brought that into jsv.js.

So this pull request is a simple copy of the export/require definition logic from uri.js to jsv.js.
