### PR TITLE
Update package.json dependencies type

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 			"url" : "git://github.com/garycourt/JSV.git"
 		}
 	],
-	"dependencies" : [],
+	"dependencies" : {},
 	"main" : "lib/jsv.js",
 	"keywords" : ["json", "schema", "validator"]
 }


### PR DESCRIPTION
The `dependencies` field of the `package.json` was a type of array, but `npm` specifies it as an object type.

This came up as I was trying to use `electron-builder` and others saw a similar issue with other packages:
https://github.com/electron-userland/electron-builder/issues/3050